### PR TITLE
Add parameter for initial value

### DIFF
--- a/lib/animated_weight_picker.dart
+++ b/lib/animated_weight_picker.dart
@@ -535,10 +535,6 @@ class _AnimatedWeightPickerState extends State<AnimatedWeightPicker> {
     double current = widget.min;
     double interval = widget.division.toPrecision(_divisionPrecision);
 
-    _selectedIndex = ((widget.initialValue ?? 0) / interval).round();
-    _scrollController =
-        FixedExtentScrollController(initialItem: _selectedIndex);
-
     int mjInterval = 0;
     int subInterval = widget.subIntervalAt;
     int mnInterval = 1;
@@ -565,7 +561,15 @@ class _AnimatedWeightPickerState extends State<AnimatedWeightPicker> {
 
       currentIndex++;
       current += interval;
+
+      if (widget.initialValue != null &&
+          current.toPrecision(_valuePrecision) == widget.initialValue) {
+        _selectedIndex = currentIndex;
+      }
     } while (current.toPrecision(2) <= widget.max);
+
+    _scrollController =
+        FixedExtentScrollController(initialItem: _selectedIndex);
     if (!onInit) setState(() {});
   }
 

--- a/lib/animated_weight_picker.dart
+++ b/lib/animated_weight_picker.dart
@@ -522,31 +522,22 @@ class _AnimatedWeightPickerState extends State<AnimatedWeightPicker> {
   final List<WheelModel> _valueList = [];
   int _selectedIndex = 0;
 
-  final _scrollController = FixedExtentScrollController();
+  late final FixedExtentScrollController _scrollController;
 
   @override
   void initState() {
     super.initState();
     createWeightList(onInit: true);
-    WidgetsFlutterBinding.ensureInitialized().addPostFrameCallback((_) {
-      scrollToInitialValue();
-    });
-  }
-
-  void scrollToInitialValue() {
-    if (widget.initialValue != null) {
-      final initialIndex = _valueList.indexWhere(
-        (element) => double.parse(element.value) == widget.initialValue,
-      );
-      if (initialIndex == -1) return;
-      _scrollController.jumpToItem(initialIndex);
-    }
   }
 
   void createWeightList({required bool onInit}) {
     _valueList.clear();
     double current = widget.min;
     double interval = widget.division.toPrecision(_divisionPrecision);
+
+    _selectedIndex = ((widget.initialValue ?? 0) / interval).round();
+    _scrollController =
+        FixedExtentScrollController(initialItem: _selectedIndex);
 
     int mjInterval = 0;
     int subInterval = widget.subIntervalAt;

--- a/lib/animated_weight_picker.dart
+++ b/lib/animated_weight_picker.dart
@@ -417,6 +417,16 @@ class AnimatedWeightPicker extends StatefulWidget {
   ///
   final Function(String newValue)? onChange;
 
+  /// Initial value of a weight picker/value picker
+  /// it's determine the initial position of picker
+  /// ```dart
+  ///
+  /// 'Added by @prasetya4di'
+  /// ```
+  /// https://www.gurutechnolabs.com/
+  /// Web & App Development Company
+  final double? initialValue;
+
   /// ```dart
   ///
   /// 'Developed by GuruTechnolabs'
@@ -476,6 +486,8 @@ class AnimatedWeightPicker extends StatefulWidget {
     this.suffix,
     //
     this.onChange,
+    //
+    this.initialValue,
   })  : assert(!(max < min)),
         assert(!(min == max)),
         assert(!(max < 1)),
@@ -495,7 +507,9 @@ class AnimatedWeightPicker extends StatefulWidget {
         assert(!(minorIntervalTextSize > 20 || minorIntervalTextSize < 1)),
         assert(!(subIntervalTextSize > 20 || subIntervalTextSize < 1)),
         assert(!(division < 0.1 || division > 1)),
-        assert(squeeze > 0);
+        assert(squeeze > 0),
+        assert(!(initialValue != null &&
+            (initialValue < min || initialValue > max)));
 
   @override
   State<AnimatedWeightPicker> createState() => _AnimatedWeightPickerState();
@@ -508,10 +522,25 @@ class _AnimatedWeightPickerState extends State<AnimatedWeightPicker> {
   final List<WheelModel> _valueList = [];
   int _selectedIndex = 0;
 
+  final _scrollController = FixedExtentScrollController();
+
   @override
   void initState() {
     super.initState();
     createWeightList(onInit: true);
+    WidgetsFlutterBinding.ensureInitialized().addPostFrameCallback((_) {
+      scrollToInitialValue();
+    });
+  }
+
+  void scrollToInitialValue() {
+    if (widget.initialValue != null) {
+      final initialIndex = _valueList.indexWhere(
+        (element) => double.parse(element.value) == widget.initialValue,
+      );
+      if (initialIndex == -1) return;
+      _scrollController.jumpToItem(initialIndex);
+    }
   }
 
   void createWeightList({required bool onInit}) {
@@ -570,6 +599,8 @@ class _AnimatedWeightPickerState extends State<AnimatedWeightPicker> {
           child: RotatedBox(
             quarterTurns: -45,
             child: ListWheelScrollView.useDelegate(
+              physics: const FixedExtentScrollPhysics(),
+              controller: _scrollController,
               offAxisFraction: 2,
               perspective: 0.003,
               itemExtent: 30,


### PR DESCRIPTION
### Background
First of all, thank you for your work. 
I am currently working on a fitness app, and I'm using your library to allow users to insert their weight. I have a function that enables users to update their weight, so I need to start the weight picker at the latest user's weight when a user wants to update their weight. 
I am adding a new `initialValue` parameter that indicates the initial point of the weight picker.

### Steps
1. Add `initialValue` parameter.
2. Add `FixedExtendScrollController` so i can jump to any index in the list view.
3. Add `PostFrameCallback` function in initState to jump to initialValue when the view is finished built